### PR TITLE
Updated for Plasma 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Not much to it, read [main.js](contents/code/main.js)
 
 ### Compatible with Plasma 6 (will not work on Plasma 5)
 
-Either install from the KDE Store or clone and run 
+Clone and run 
 ```sh
 kpackagetool6 --type=KWin/Script -i kde-alt-f4-desktop
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 Not much to it, read [main.js](contents/code/main.js)
 
 ## Install
+
+# Compatible with Plasma 6 (will not work on Plasma 5)
+
 Either install from the KDE Store or clone and run 
 ```sh
-kpackagetool5 --type=KWin/Script -i kde-alt-f4-desktop
+kpackagetool6 --type=KWin/Script -i kde-alt-f4-desktop
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Not much to it, read [main.js](contents/code/main.js)
 
 ## Install
 
-# Compatible with Plasma 6 (will not work on Plasma 5)
+### Compatible with Plasma 6 (will not work on Plasma 5)
 
 Either install from the KDE Store or clone and run 
 ```sh

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,6 +1,6 @@
 registerShortcut("Alt-F4-Desktop", "Close Window or show Logout Option", "Alt+F4", function() {
     if (workspace.activeWindow.desktopWindow) {
-        callDBus("org.kde.LogoutPrompt", "/LogoutPrompt", "", "promptLogout")
+        callDBus("org.kde.LogoutPrompt", "/LogoutPrompt", "", "promptShutDown")
     } else {
         workspace.activeWindow.closeWindow()
     }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,8 +1,8 @@
 registerShortcut("Alt-F4-Desktop", "Close Window or show Logout Option", "Alt+F4", function() {
-    if (workspace.activeClient.desktopWindow) {
-        callDBus("org.kde.ksmserver", "/KSMServer", "org.kde.KSMServerInterface", "logout", 1, 2, 3)
+    if (workspace.activeWindow.desktopWindow) {
+        callDBus("org.kde.LogoutPrompt", "/LogoutPrompt", "", "promptLogout")
     } else {
-        workspace.activeClient.closeWindow()
+        workspace.activeWindow.closeWindow()
     }
 })
 


### PR DESCRIPTION
Updated the script to work on Plasma 6. Below is a link to the different methods that can be called on that LogoutPrompt interface to change the default behavior (shutdown, logout, etc.).

https://github.com/KDE/plasma-workspace/blob/master/ksmserver/org.kde.LogoutPrompt.xml